### PR TITLE
Fixed not properly enabling/disabling editor when using reactive forms

### DIFF
--- a/projects/ngx-trumbowyg/src/lib/commons/editor-base.ts
+++ b/projects/ngx-trumbowyg/src/lib/commons/editor-base.ts
@@ -42,7 +42,7 @@ export abstract class EditorBase implements ControlValueAccessor, OnInit, AfterV
     const editor = $(this._editor.nativeElement)
       .trumbowyg({ ...this._config, ...this.options })
       .on('tbwinit', () => {
-        $(this._editor.nativeElement).trumbowyg(this._disabled ? 'disable' : 'enable');
+        this.setDisabledState(this._disabled);
         this.setContent(this._initValue);
       })
       .on('tbwchange', () => {
@@ -78,6 +78,10 @@ export abstract class EditorBase implements ControlValueAccessor, OnInit, AfterV
 
   setDisabledState(disabled: boolean): void {
     this._disabled = disabled;
+
+    if (this._editor) {
+      $(this._editor.nativeElement).trumbowyg(this._disabled ? 'disable' : 'enable');
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,7 @@
 <h1>{{form.value | json}}</h1>
 
+<button (click)="toggleDisabled()">Toggle Form disabled</button>
+
 <form [formGroup]="form">
   <ngx-trumbowyg-editor id="editor" formControlName="foo"></ngx-trumbowyg-editor>
 </form>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -40,4 +40,13 @@ export class AppComponent implements AfterViewInit, OnDestroy {
   ngOnDestroy(): void {
     this._sub.unsubscribe();
   }
+
+  toggleDisabled(): void {
+    const control = this.form.get("foo");
+    if (control.disabled) {
+      control.enable();
+    } else {
+      control.disable();
+    }
+  }
 }


### PR DESCRIPTION
Previously using the `formControl.enable()` and `formControl.disable()` did not actually enable or disable the trumbowyg editor.